### PR TITLE
build: setting application service type as NodePort.

### DIFF
--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -4,6 +4,7 @@ metadata:
   name: fastapi-service
   namespace: fastapi
 spec:
+  type: NodePort
   selector:
     app: fastapi
   ports:


### PR DESCRIPTION
build: setting application service type as NodePort.